### PR TITLE
xseg: Change posixfd directory permissions

### DIFF
--- a/src/xseg_posixfd.c
+++ b/src/xseg_posixfd.c
@@ -210,7 +210,10 @@ static void posixfd_local_signal_quit(struct xseg *xseg, xport portno)
 static int posixfd_remote_signal_init(void)
 {
 	int r;
-	r = mkdir(POSIXFD_DIR, 01755);
+	mode_t oldumask;
+	oldumask = umask(0000);
+	r = mkdir(POSIXFD_DIR, 01777);
+	umask(oldumask);
 
 	if (r < 0) {
 		if (errno != EEXIST) // && isdir(POSIXFD_DIR)


### PR DESCRIPTION
Change '/run/shm/posixfd' directory permissions from '01755'
to '01777'. An ordinary user can now create/unlink his named
pipes.
